### PR TITLE
Fix incorrect <spans> tag to <span> tag in _navbar.html.erb

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -35,7 +35,7 @@
               <span><%= notif.title %></span>
               <span class="date-notif"><%= notif.created_at.strftime("%d/%m %H:%M") %></span>
             </span>
-            <spans class="text-notif"><%= notif.content %></spans>
+            <span class="text-notif"><%= notif.content %></span>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Fix incorrect spans tag to span tag in _navbar.html.erb

This pull request addresses an issue in the _navbar.html.erb file where the incorrect <spans> tag was used instead of the correct <span> tag. The change ensures proper HTML structure and fixes the issue preventing proper rendering of content.

Replaced <spans> with <span> on line 38 (previously line 37 before reindentation).
No other changes were made to the file.